### PR TITLE
Add Upstash rate limiting and richer SEO metadata

### DIFF
--- a/__tests__/contact.test.ts
+++ b/__tests__/contact.test.ts
@@ -22,6 +22,9 @@ describe("/api/contact", () => {
     process.env.RESEND_API_KEY = "test-api-key";
     process.env.CONTACT_EMAIL = "test@example.com";
     process.env.FROM_EMAIL = "sender@example.com";
+    delete process.env.SEND_AUTO_REPLY;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
 
     // Reset rate limit store before each test
     __test__.resetRateLimitStore();
@@ -48,6 +51,9 @@ describe("/api/contact", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    delete process.env.SEND_AUTO_REPLY;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
   });
 
   it("should reject non-POST requests", async () => {
@@ -157,6 +163,7 @@ describe("/api/contact", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(res._getHeaders()["x-ratelimit-limit"]).toBeDefined();
     expect(res._getHeaders()["x-ratelimit-remaining"]).toBeDefined();
+    expect(res._getHeaders()["x-ratelimit-reset"]).toBeDefined();
   });
 
   it("should enforce rate limiting after max requests", async () => {
@@ -175,6 +182,80 @@ describe("/api/contact", () => {
     const data = JSON.parse(res._getData());
     expect(data.error).toBe("Too many requests");
     expect(data.details).toContain("Maximum 3 submissions per hour");
+    expect(res._getHeaders()["x-ratelimit-remaining"]).toBe("0");
+  });
+
+  it("should use Redis rate limiting when Upstash is configured", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+
+    const originalFetch = global.fetch;
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 1 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 1 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 3600 }),
+      });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { req, res } = makeRequest();
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()["x-ratelimit-remaining"]).toBe("2");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.upstash.io/INCR/contact%3Arate-limit%3Aunknown",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer test-token",
+        },
+      })
+    );
+
+    global.fetch = originalFetch;
+  });
+
+  it("should rate limit requests from Redis when the limit is exceeded", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 4 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 1200 }),
+      }) as unknown as typeof fetch;
+
+    const { req, res } = makeRequest();
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeaders()["x-ratelimit-remaining"]).toBe("0");
+
+    global.fetch = originalFetch;
+  });
+
+  it("should fail closed when Redis rate limiting is partially configured", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const { req, res } = makeRequest();
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    const data = JSON.parse(res._getData());
+    expect(data.error).toBe("Internal server error");
   });
 
   it("should return error when CONTACT_EMAIL is not set", async () => {

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -77,7 +77,8 @@ describe('Home Page', () => {
     it('toggles mobile menu when hamburger is clicked', () => {
       render(<Home />);
 
-      const hamburgerButton = screen.getByRole('button', { name: '' });
+      const hamburgerButton = screen.getByRole('button', { name: 'Open navigation menu' });
+      expect(hamburgerButton).toHaveAttribute('aria-expanded', 'false');
 
       // Mobile menu should not be visible initially
       const mobileLinks = screen.queryAllByText('About');
@@ -85,6 +86,7 @@ describe('Home Page', () => {
 
       // Click to open
       fireEvent.click(hamburgerButton);
+      expect(screen.getByRole('button', { name: 'Close navigation menu' })).toHaveAttribute('aria-expanded', 'true');
 
       // Check that menu items are present
       const openLinks = screen.queryAllByText('About');
@@ -94,7 +96,7 @@ describe('Home Page', () => {
     it('closes mobile menu when a link is clicked', () => {
       render(<Home />);
 
-      const hamburgerButton = screen.getByRole('button', { name: '' });
+      const hamburgerButton = screen.getByRole('button', { name: 'Open navigation menu' });
 
       // Open mobile menu
       fireEvent.click(hamburgerButton);
@@ -289,6 +291,24 @@ describe('Home Page', () => {
       // The title is set in the Head component
       expect(screen.getByText('Rodney Jan Mandap | Freelance Software Engineer')).toBeInTheDocument();
     });
+
+    it('sets social sharing and structured metadata', () => {
+      render(<Home />);
+
+      expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute(
+        'href',
+        'https://rodneymandap.github.io'
+      );
+      expect(document.querySelector('meta[property="og:title"]')).toHaveAttribute(
+        'content',
+        'Rodney Jan Mandap | Freelance Software Engineer'
+      );
+      expect(document.querySelector('meta[name="twitter:card"]')).toHaveAttribute(
+        'content',
+        'summary_large_image'
+      );
+      expect(document.querySelector('script[type="application/ld+json"]')).toBeInTheDocument();
+    });
   });
 
   describe('Responsive Design', () => {
@@ -334,6 +354,12 @@ describe('Home Page', () => {
   });
 
   describe('Interactive Elements', () => {
+    it('labels icon-only buttons for assistive technology', () => {
+      render(<Home />);
+
+      expect(screen.getByRole('button', { name: 'Open navigation menu' })).toBeInTheDocument();
+    });
+
     it('has working navigation anchors', () => {
       render(<Home />);
 

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -10,6 +10,7 @@ interface RateLimitEntry {
 
 const rateLimitStore = new Map<string, RateLimitEntry>();
 const RATE_LIMIT_WINDOW = 60 * 60 * 1000; // 1 hour
+const RATE_LIMIT_WINDOW_SECONDS = RATE_LIMIT_WINDOW / 1000;
 const MAX_REQUESTS_PER_WINDOW = 3; // Maximum 3 submissions per hour per IP
 
 // Export for testing purposes
@@ -55,7 +56,14 @@ function getClientIP(req: NextApiRequest): string {
   return ip;
 }
 
-function checkRateLimit(ip: string): { allowed: boolean; remaining: number } {
+type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  resetSeconds?: number;
+  source: "memory" | "redis";
+};
+
+function checkInMemoryRateLimit(ip: string): RateLimitResult {
   const now = Date.now();
   const entry = rateLimitStore.get(ip);
 
@@ -65,15 +73,98 @@ function checkRateLimit(ip: string): { allowed: boolean; remaining: number } {
       count: 1,
       resetTime: now + RATE_LIMIT_WINDOW,
     });
-    return { allowed: true, remaining: MAX_REQUESTS_PER_WINDOW - 1 };
+    return {
+      allowed: true,
+      remaining: MAX_REQUESTS_PER_WINDOW - 1,
+      resetSeconds: RATE_LIMIT_WINDOW_SECONDS,
+      source: "memory",
+    };
   }
 
   if (entry.count >= MAX_REQUESTS_PER_WINDOW) {
-    return { allowed: false, remaining: 0 };
+    return {
+      allowed: false,
+      remaining: 0,
+      resetSeconds: Math.ceil((entry.resetTime - now) / 1000),
+      source: "memory",
+    };
   }
 
   entry.count++;
-  return { allowed: true, remaining: MAX_REQUESTS_PER_WINDOW - entry.count };
+  return {
+    allowed: true,
+    remaining: MAX_REQUESTS_PER_WINDOW - entry.count,
+    resetSeconds: Math.ceil((entry.resetTime - now) / 1000),
+    source: "memory",
+  };
+}
+
+async function upstashCommand<T>(
+  redisUrl: string,
+  token: string,
+  command: Array<string | number>
+): Promise<T> {
+  const endpoint = `${redisUrl}/${command
+    .map((part) => encodeURIComponent(String(part)))
+    .join("/")}`;
+  const response = await fetch(endpoint, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Rate limit store returned ${response.status}`);
+  }
+
+  const payload = (await response.json()) as { result?: T; error?: string };
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+
+  return payload.result as T;
+}
+
+async function checkRedisRateLimit(ip: string): Promise<RateLimitResult | null> {
+  const redisUrl = process.env.UPSTASH_REDIS_REST_URL?.replace(/\/$/, "");
+  const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!redisUrl && !redisToken) {
+    return null;
+  }
+
+  if (!redisUrl || !redisToken) {
+    throw new Error("Redis rate limit store is partially configured");
+  }
+
+  const key = `contact:rate-limit:${ip}`;
+  const count = await upstashCommand<number>(redisUrl, redisToken, [
+    "INCR",
+    key,
+  ]);
+
+  if (count === 1) {
+    await upstashCommand<number>(redisUrl, redisToken, [
+      "EXPIRE",
+      key,
+      RATE_LIMIT_WINDOW_SECONDS,
+    ]);
+  }
+
+  const ttl = await upstashCommand<number>(redisUrl, redisToken, ["TTL", key]);
+  const remaining = Math.max(MAX_REQUESTS_PER_WINDOW - count, 0);
+
+  return {
+    allowed: count <= MAX_REQUESTS_PER_WINDOW,
+    remaining,
+    resetSeconds: ttl > 0 ? ttl : RATE_LIMIT_WINDOW_SECONDS,
+    source: "redis",
+  };
+}
+
+async function checkRateLimit(ip: string): Promise<RateLimitResult> {
+  const redisRateLimit = await checkRedisRateLimit(ip);
+  return redisRateLimit || checkInMemoryRateLimit(ip);
 }
 
 function validateEmail(email: string): boolean {
@@ -168,19 +259,25 @@ export default async function handler(
   try {
     // Check rate limit
     const clientIP = getClientIP(req);
-    const rateLimit = checkRateLimit(clientIP);
+    const rateLimit = await checkRateLimit(clientIP);
+
+    // Set rate limit headers
+    res.setHeader("X-RateLimit-Limit", MAX_REQUESTS_PER_WINDOW.toString());
+    res.setHeader("X-RateLimit-Remaining", rateLimit.remaining.toString());
+    if (rateLimit.resetSeconds) {
+      res.setHeader("X-RateLimit-Reset", rateLimit.resetSeconds.toString());
+    }
 
     if (!rateLimit.allowed) {
-      logger.warn("Rate limit exceeded", { clientIP });
+      logger.warn("Rate limit exceeded", {
+        clientIP,
+        source: rateLimit.source,
+      });
       return res.status(429).json({
         error: "Too many requests",
         details: "Maximum 3 submissions per hour. Please try again later.",
       });
     }
-
-    // Set rate limit headers
-    res.setHeader("X-RateLimit-Limit", MAX_REQUESTS_PER_WINDOW.toString());
-    res.setHeader("X-RateLimit-Remaining", rateLimit.remaining.toString());
 
     // Parse and validate request body
     const formData: ContactFormData = req.body;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,36 @@ import Head from "next/head";
 import Image from "next/image";
 import { useState } from "react";
 
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://rodneymandap.github.io";
+const siteTitle = "Rodney Jan Mandap | Freelance Software Engineer";
+const siteDescription =
+  "Rodney Jan Mandap is a freelance Python and Django software engineer building automation platforms, internal tools, REST APIs, and scalable web applications.";
+const socialImageUrl = `${siteUrl}/myPic.jpeg`;
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Rodney Jan Mandap",
+  url: siteUrl,
+  image: socialImageUrl,
+  jobTitle: "Freelance Software Engineer",
+  description: siteDescription,
+  sameAs: [
+    "https://github.com/rodneymandap",
+    "https://www.linkedin.com/in/rjmandap/",
+  ],
+  knowsAbout: [
+    "Python",
+    "Django",
+    "Django REST Framework",
+    "REST APIs",
+    "Automation",
+    "Internal tools",
+    "Azure",
+    "Docker",
+  ],
+};
+
 function calculateYearsOfExperience(): number {
   const startYear: number = 2016;
   const currentYear: number = new Date().getFullYear();
@@ -269,6 +299,7 @@ export default function Home(): JSX.Element {
             <button
               onClick={() => setShowToast(false)}
               className="flex-shrink-0 text-dark-500 hover:text-white transition-colors"
+              aria-label="Dismiss notification"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -279,10 +310,34 @@ export default function Home(): JSX.Element {
       )}
 
       <Head>
-        <title>Rodney Jan Mandap | Freelance Software Engineer</title>
-        <meta name="description" content="Rodney Jan Mandap - Freelance Software Engineer specializing in web applications, REST APIs, and scalable Python solutions." />
+        <title>{siteTitle}</title>
+        <meta name="description" content={siteDescription} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="keywords"
+          content="Rodney Jan Mandap, freelance software engineer, Python developer, Django developer, REST API developer, automation engineer, internal tools"
+        />
+        <meta name="author" content="Rodney Jan Mandap" />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href={siteUrl} />
         <link rel="icon" href="/favicon.ico" />
+        <meta property="og:type" content="profile" />
+        <meta property="og:title" content={siteTitle} />
+        <meta property="og:description" content={siteDescription} />
+        <meta property="og:url" content={siteUrl} />
+        <meta property="og:site_name" content="Rodney Jan Mandap" />
+        <meta property="og:image" content={socialImageUrl} />
+        <meta property="og:image:alt" content="Rodney Jan Mandap" />
+        <meta property="profile:first_name" content="Rodney Jan" />
+        <meta property="profile:last_name" content="Mandap" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={siteTitle} />
+        <meta name="twitter:description" content={siteDescription} />
+        <meta name="twitter:image" content={socialImageUrl} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
       </Head>
 
       <nav className="fixed top-0 left-0 right-0 z-50 bg-dark-950/80 backdrop-blur-md border-b border-dark-800/50">
@@ -321,6 +376,9 @@ export default function Home(): JSX.Element {
             <button
               className="md:hidden text-white p-2"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+              aria-expanded={mobileMenuOpen}
+              aria-controls="mobile-navigation"
             >
               <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 {mobileMenuOpen ? (
@@ -333,7 +391,7 @@ export default function Home(): JSX.Element {
           </div>
 
           {mobileMenuOpen && (
-            <div className="md:hidden py-4 border-t border-dark-800">
+            <div id="mobile-navigation" className="md:hidden py-4 border-t border-dark-800">
               {navLinks.map((link) => (
                 <a
                   key={link.name}


### PR DESCRIPTION
## Summary
- Add Upstash-backed rate limiting with a memory fallback, reset headers, and fail-closed behavior for partial config
- Improve homepage SEO and social sharing metadata with canonical, Open Graph, Twitter, and structured data tags
- Add accessible labels and state attributes for the mobile menu and dismiss button
- Extend tests to cover Redis rate limiting, rate-limit headers, accessibility labels, and metadata output

## Testing
- Added unit coverage for contact API rate limiting across memory and Redis paths
- Added UI test coverage for navigation accessibility and page metadata