### PR TITLE
Update years of experience to start in 2017

### DIFF
--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -44,7 +44,7 @@ describe('Home Page', () => {
       render(<Home />);
 
       const currentYear = new Date().getFullYear();
-      const expectedYears = currentYear - 2016;
+      const expectedYears = currentYear - 2017;
 
       expect(screen.getByText(`${expectedYears}+`)).toBeInTheDocument();
       expect(screen.getByText('Years Experience')).toBeInTheDocument();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { useState } from "react";
 
 function calculateYearsOfExperience(): number {
-  const startYear: number = 2016;
+  const startYear: number = 2017;
   const currentYear: number = new Date().getFullYear();
   return currentYear - startYear;
 }


### PR DESCRIPTION
## Summary
- Update the home page experience calculation to start from 2017
- Adjust the corresponding unit test to match the new years-experience value

## Testing
- Not run (not requested)