### PR TITLE
Add OAuth-backed YNAB MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 - ✅ **Validation** - Client-side and server-side validation
 - 🎨 **Modern UI** - Responsive design with Tailwind CSS
 - ✨ **Toast Notifications** - User-friendly success/error feedback
+- 🤖 **YNAB MCP Server** - Read-only MCP endpoint for AI-assisted personal budget queries
 
 ## Getting Started
 
@@ -160,6 +161,25 @@ Check out the [Next.js deployment documentation](https://nextjs.org/docs/deploym
 | `CONTACT_EMAIL` | Email address to receive contact form submissions | Yes |
 | `FROM_EMAIL` | Sender email address (must be verified in Resend) | No (defaults to onboarding@resend.dev) |
 | `SEND_AUTO_REPLY` | Set to `true` to send auto-reply to submitters | No (defaults to false) |
+
+### YNAB MCP Server
+
+The YNAB MCP endpoint is available at `/api/ynab-mcp`. It is designed for personal AI clients and keeps the YNAB token server-side.
+
+Required Vercel environment variable:
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `YNAB_CLIENT_ID` | OAuth application client ID from YNAB Developer Settings | Yes for multi-user OAuth |
+| `YNAB_CLIENT_SECRET` | OAuth application client secret from YNAB Developer Settings | Yes for multi-user OAuth |
+| `YNAB_REDIRECT_URI` | OAuth callback URL | Recommended |
+| `UPSTASH_REDIS_REST_URL` | Persistent OAuth token store URL | Yes for production OAuth |
+| `UPSTASH_REDIS_REST_TOKEN` | Persistent OAuth token store token | Yes for production OAuth |
+| `YNAB_ACCESS_TOKEN` | Owner-only fallback personal access token from YNAB Developer Settings | Optional |
+| `MCP_API_KEY` | Owner-only fallback shared secret | Optional |
+| `YNAB_API_BASE` | YNAB API base URL | No (defaults to https://api.ynab.com/v1) |
+
+See [docs/ynab-mcp.md](docs/ynab-mcp.md) for setup and provisioning steps.
 
 ## Security Features
 

--- a/__tests__/ynab-mcp.test.ts
+++ b/__tests__/ynab-mcp.test.ts
@@ -1,0 +1,468 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import handler from "../pages/api/ynab-mcp";
+
+const originalEnv = process.env;
+
+function createMockResponse() {
+  const res: Partial<NextApiResponse> & {
+    status: jest.Mock;
+    json: jest.Mock;
+    end: jest.Mock;
+    setHeader: jest.Mock;
+  } = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    end: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+  return res as NextApiResponse & typeof res;
+}
+
+function createMockRequest(
+  method: string,
+  body: unknown = {},
+  headers: Record<string, string> = {}
+): NextApiRequest {
+  return {
+    method,
+    headers,
+    query: {},
+    body,
+  } as NextApiRequest;
+}
+
+describe("/api/ynab-mcp", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.MCP_API_KEY;
+    process.env.YNAB_ACCESS_TOKEN = "ynab-test-token";
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns health details for GET requests", async () => {
+    const req = createMockRequest("GET");
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: true,
+        endpoint: "/api/ynab-mcp",
+      })
+    );
+  });
+
+  it("returns MCP initialization details", async () => {
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonrpc: "2.0",
+        id: 1,
+        result: expect.objectContaining({
+          capabilities: { tools: {} },
+          serverInfo: expect.objectContaining({ name: "rodney-ynab-mcp" }),
+        }),
+      })
+    );
+  });
+
+  it("lists the YNAB tools", async () => {
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: "tools",
+      method: "tools/list",
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].result.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "ynab_list_plans" }),
+        expect.objectContaining({ name: "ynab_list_transactions" }),
+      ])
+    );
+  });
+
+  it("requires a valid owner token for tool calls when MCP_API_KEY is configured", async () => {
+    process.env.MCP_API_KEY = "secret";
+    delete process.env.YNAB_ACCESS_TOKEN;
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "ynab_list_plans",
+        arguments: {},
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].error.message).toContain("No YNAB access token");
+  });
+
+  it("calls YNAB when a tool is invoked", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { plans: [{ id: "plan-1", name: "Main" }] } }),
+    });
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "ynab_list_plans",
+        arguments: {},
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.ynab.com/v1/plans",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ynab-test-token",
+        }),
+      })
+    );
+    expect(res.json.mock.calls[0][0].result.content[0].text).toContain("Main");
+  });
+
+  it("filters closed accounts by default", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          accounts: [
+            { id: "open", name: "Checking", closed: false },
+            { id: "closed", name: "Old", closed: true },
+          ],
+        },
+      }),
+    });
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "ynab_list_accounts",
+        arguments: {},
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    const text = res.json.mock.calls[0][0].result.content[0].text;
+    expect(text).toContain("Checking");
+    expect(text).not.toContain("Old");
+  });
+
+  it("filters hidden categories by default", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          category_groups: [
+            {
+              name: "Visible",
+              hidden: false,
+              deleted: false,
+              categories: [
+                { name: "Groceries", hidden: false, deleted: false },
+                { name: "Hidden Category", hidden: true, deleted: false },
+              ],
+            },
+            { name: "Hidden Group", hidden: true, deleted: false, categories: [] },
+          ],
+        },
+      }),
+    });
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: {
+        name: "ynab_list_categories",
+        arguments: {},
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    const text = res.json.mock.calls[0][0].result.content[0].text;
+    expect(text).toContain("Groceries");
+    expect(text).not.toContain("Hidden Category");
+    expect(text).not.toContain("Hidden Group");
+  });
+
+  it("limits transactions and supports account-specific transaction URLs", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          transactions: [
+            { id: "1" },
+            { id: "2" },
+            { id: "3" },
+          ],
+        },
+      }),
+    });
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: {
+        name: "ynab_list_transactions",
+        arguments: {
+          plan_id: "plan-1",
+          account_id: "account-1",
+          since_date: "2026-07-01",
+          limit: 2,
+        },
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.ynab.com/v1/plans/plan-1/accounts/account-1/transactions?since_date=2026-07-01",
+      expect.any(Object)
+    );
+    const text = res.json.mock.calls[0][0].result.content[0].text;
+    expect(text).toContain('"returned": 2');
+    expect(text).toContain('"total_available": 3');
+  });
+
+  it("gets the current month summary when no month is passed", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { month: { month: "2026-07-01" } } }),
+    });
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: {
+        name: "ynab_get_month",
+        arguments: { plan_id: "plan-1" },
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain(
+      "/plans/plan-1/months/"
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("builds a plan overview from multiple YNAB calls", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { accounts: [] } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { category_groups: [] } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { month: {} } }) });
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: {
+        name: "ynab_get_plan_overview",
+        arguments: { month: "2026-07-01" },
+      },
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(res.json.mock.calls[0][0].result.content[0].text).toContain(
+      "month_summary"
+    );
+  });
+
+  it("accepts authorized bearer requests when MCP_API_KEY is configured", async () => {
+    process.env.MCP_API_KEY = "secret";
+    const req = createMockRequest(
+      "POST",
+      {
+        jsonrpc: "2.0",
+        id: 8,
+        method: "tools/list",
+      },
+      { authorization: "Bearer secret" }
+    );
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("handles notifications without a response body", async () => {
+    const req = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it("returns JSON-RPC errors for unknown methods and tools", async () => {
+    const unknownMethodReq = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 9,
+      method: "missing/method",
+    });
+    const unknownMethodRes = createMockResponse();
+    await handler(unknownMethodReq, unknownMethodRes);
+
+    expect(unknownMethodRes.json.mock.calls[0][0].error.code).toBe(-32601);
+
+    const unknownToolReq = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/call",
+      params: { name: "missing_tool", arguments: {} },
+    });
+    const unknownToolRes = createMockResponse();
+    await handler(unknownToolReq, unknownToolRes);
+
+    expect(unknownToolRes.json.mock.calls[0][0].error.code).toBe(-32603);
+  });
+
+  it("handles YNAB configuration and API errors as tool errors", async () => {
+    delete process.env.YNAB_ACCESS_TOKEN;
+    const missingTokenReq = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/call",
+      params: { name: "ynab_list_plans", arguments: {} },
+    });
+    const missingTokenRes = createMockResponse();
+    await handler(missingTokenReq, missingTokenRes);
+
+    expect(missingTokenRes.json.mock.calls[0][0].error.message).toContain(
+      "No YNAB access token"
+    );
+
+    process.env.YNAB_ACCESS_TOKEN = "ynab-test-token";
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: { detail: "Rate limited" } }),
+    });
+    const apiErrorReq = createMockRequest("POST", {
+      jsonrpc: "2.0",
+      id: 12,
+      method: "tools/call",
+      params: { name: "ynab_list_plans", arguments: {} },
+    });
+    const apiErrorRes = createMockResponse();
+    await handler(apiErrorReq, apiErrorRes);
+
+    expect(apiErrorRes.json.mock.calls[0][0].error.message).toBe("Rate limited");
+  });
+
+  it("handles batches, invalid JSON, and unsupported methods", async () => {
+    const batchReq = createMockRequest("POST", [
+      { jsonrpc: "2.0", id: "a", method: "tools/list" },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+    ]);
+    const batchRes = createMockResponse();
+    await handler(batchReq, batchRes);
+
+    expect(batchRes.json.mock.calls[0][0]).toHaveLength(1);
+
+    const invalidJsonReq = createMockRequest("POST", "{");
+    const invalidJsonRes = createMockResponse();
+    await handler(invalidJsonReq, invalidJsonRes);
+
+    expect(invalidJsonRes.status).toHaveBeenCalledWith(400);
+
+    const putReq = createMockRequest("PUT");
+    const putRes = createMockResponse();
+    await handler(putReq, putRes);
+
+    expect(putRes.status).toHaveBeenCalledWith(405);
+    expect(putRes.setHeader).toHaveBeenCalledWith("Allow", "GET, POST");
+  });
+
+  it("uses OAuth session bearer tokens for tool calls", async () => {
+    delete process.env.YNAB_ACCESS_TOKEN;
+    process.env.YNAB_CLIENT_ID = "client-id";
+    process.env.YNAB_CLIENT_SECRET = "client-secret";
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example.com";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "redis-token";
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: JSON.stringify({
+            accessToken: "oauth-access-token",
+            refreshToken: "oauth-refresh-token",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          }),
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { plans: [{ id: "plan-1", name: "OAuth Plan" }] } }),
+      });
+    const req = createMockRequest(
+      "POST",
+      {
+        jsonrpc: "2.0",
+        id: 13,
+        method: "tools/call",
+        params: { name: "ynab_list_plans", arguments: {} },
+      },
+      { authorization: "Bearer ynab_session" }
+    );
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      "https://api.ynab.com/v1/plans",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer oauth-access-token",
+        }),
+      })
+    );
+    expect(res.json.mock.calls[0][0].result.content[0].text).toContain("OAuth Plan");
+  });
+});

--- a/__tests__/ynab-oauth.test.ts
+++ b/__tests__/ynab-oauth.test.ts
@@ -1,0 +1,130 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import connectHandler from "../pages/api/ynab/oauth/connect";
+import callbackHandler from "../pages/api/ynab/oauth/callback";
+import { __resetYnabOAuthMemoryStore } from "../lib/ynab-oauth";
+
+const originalEnv = process.env;
+
+function createMockResponse() {
+  const res: Partial<NextApiResponse> & {
+    status: jest.Mock;
+    json: jest.Mock;
+    redirect: jest.Mock;
+    send: jest.Mock;
+    setHeader: jest.Mock;
+  } = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    redirect: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+  return res as NextApiResponse & typeof res;
+}
+
+function createMockRequest(
+  method: string,
+  query: Record<string, string> = {}
+): NextApiRequest {
+  return {
+    method,
+    headers: {
+      host: "mcp.example.com",
+      "x-forwarded-proto": "https",
+    },
+    query,
+    body: {},
+  } as NextApiRequest;
+}
+
+describe("YNAB OAuth endpoints", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    __resetYnabOAuthMemoryStore();
+    process.env = { ...originalEnv };
+    process.env.YNAB_CLIENT_ID = "client-id";
+    process.env.YNAB_CLIENT_SECRET = "client-secret";
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("redirects users to YNAB with read-only authorization code OAuth", async () => {
+    const req = createMockRequest("GET");
+    const res = createMockResponse();
+
+    await connectHandler(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, expect.stringContaining("https://app.ynab.com/oauth/authorize"));
+    const url = new URL(res.redirect.mock.calls[0][1]);
+    expect(url.searchParams.get("client_id")).toBe("client-id");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("read-only");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://mcp.example.com/api/ynab/oauth/callback"
+    );
+  });
+
+  it("exchanges the callback code and returns an MCP session token", async () => {
+    const connectReq = createMockRequest("GET");
+    const connectRes = createMockResponse();
+
+    await connectHandler(connectReq, connectRes);
+    const authorizationUrl = new URL(connectRes.redirect.mock.calls[0][1]);
+    const state = authorizationUrl.searchParams.get("state") || "";
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: "ynab-access-token",
+        token_type: "bearer",
+        expires_in: 7200,
+        refresh_token: "ynab-refresh-token",
+        scope: "read-only",
+      }),
+    });
+    const callbackReq = createMockRequest("GET", { code: "auth-code", state });
+    const callbackRes = createMockResponse();
+
+    await callbackHandler(callbackReq, callbackRes);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://app.ynab.com/oauth/token",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("grant_type=authorization_code"),
+      })
+    );
+    expect(callbackRes.status).toHaveBeenCalledWith(200);
+    expect(callbackRes.send.mock.calls[0][0]).toContain("ynab_");
+  });
+
+  it("rejects callbacks with missing or expired state", async () => {
+    const req = createMockRequest("GET", { code: "auth-code", state: "bad-state" });
+    const res = createMockResponse();
+
+    await callbackHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send.mock.calls[0][0]).toContain("invalid or expired");
+  });
+
+  it("rejects unsupported methods", async () => {
+    const connectReq = createMockRequest("POST");
+    const connectRes = createMockResponse();
+    await connectHandler(connectReq, connectRes);
+
+    expect(connectRes.status).toHaveBeenCalledWith(405);
+
+    const callbackReq = createMockRequest("POST");
+    const callbackRes = createMockResponse();
+    await callbackHandler(callbackReq, callbackRes);
+
+    expect(callbackRes.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/docs/ynab-mcp.md
+++ b/docs/ynab-mcp.md
@@ -1,0 +1,139 @@
+# YNAB MCP Server
+
+This project includes a read-only MCP endpoint for YNAB at:
+
+```text
+/api/ynab-mcp
+```
+
+It exposes tools for listing plans, accounts, categories, month summaries, transactions, and a compact plan overview.
+
+Users connect their own YNAB accounts through OAuth:
+
+```text
+/api/ynab/oauth/connect
+```
+
+## Environment Variables
+
+Add these variables in Vercel under Project Settings > Environment Variables:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `YNAB_CLIENT_ID` | Yes | OAuth application client ID from YNAB Developer Settings. |
+| `YNAB_CLIENT_SECRET` | Yes | OAuth application client secret from YNAB Developer Settings. |
+| `YNAB_REDIRECT_URI` | Recommended | Full callback URL, for example `https://mcp.rodneymandap.com/api/ynab/oauth/callback`. |
+| `UPSTASH_REDIS_REST_URL` | Yes for production OAuth | Persistent token store URL. |
+| `UPSTASH_REDIS_REST_TOKEN` | Yes for production OAuth | Persistent token store token. |
+| `YNAB_ACCESS_TOKEN` | Optional | Owner-only fallback personal access token. |
+| `MCP_API_KEY` | Optional | Shared secret for the owner-only fallback mode. |
+| `YNAB_API_BASE` | No | Defaults to `https://api.ynab.com/v1`. |
+
+## Create the YNAB OAuth App
+
+1. Sign in to the YNAB web app.
+2. Open Account Settings.
+3. Open Developer Settings.
+4. Under OAuth Applications, create a new application.
+5. Add the redirect URI:
+
+```text
+https://mcp.rodneymandap.com/api/ynab/oauth/callback
+```
+
+For local development, also add:
+
+```text
+http://localhost:3000/api/ynab/oauth/callback
+```
+
+6. Copy the client ID and client secret into Vercel as `YNAB_CLIENT_ID` and `YNAB_CLIENT_SECRET`.
+7. Request read-only access only. The server also sends `scope=read-only` during authorization.
+
+YNAB starts new OAuth applications in Restricted Mode. That currently allows a limited number of users outside the application owner until YNAB reviews and approves the app.
+
+## Token Storage
+
+OAuth access tokens expire and refresh tokens must be stored server-side. For Vercel, use Upstash Redis:
+
+1. Create a Redis database in Upstash.
+2. Copy the REST URL and REST token.
+3. Add them to Vercel as `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`.
+
+Without Redis, the code falls back to in-memory storage for local development only. That is not reliable on Vercel because serverless functions can restart.
+
+## Deploy on Vercel
+
+### Option A: Same Portfolio Project
+
+Use this when the MCP server is only for your own use.
+
+1. Push this branch to GitHub.
+2. Open the existing portfolio project in Vercel.
+3. Add `YNAB_CLIENT_ID`, `YNAB_CLIENT_SECRET`, `YNAB_REDIRECT_URI`, `UPSTASH_REDIS_REST_URL`, and `UPSTASH_REDIS_REST_TOKEN`.
+4. Deploy.
+5. Users connect at:
+
+```text
+https://rodneymandap.com/api/ynab/oauth/connect
+```
+
+6. Use this MCP URL:
+
+```text
+https://rodneymandap.com/api/ynab-mcp
+```
+
+### Option B: Separate Vercel Project and Subdomain
+
+Use this when you want cleaner logs, environment variables, and deployment history.
+
+1. Create a new Vercel project from the same repository.
+2. Set the production branch to the branch or app you want to deploy.
+3. Add `YNAB_CLIENT_ID`, `YNAB_CLIENT_SECRET`, `YNAB_REDIRECT_URI`, `UPSTASH_REDIS_REST_URL`, and `UPSTASH_REDIS_REST_TOKEN`.
+4. Add a custom domain such as `mcp.rodneymandap.com`.
+5. Users connect at:
+
+```text
+https://mcp.rodneymandap.com/api/ynab/oauth/connect
+```
+
+6. Use this MCP URL:
+
+```text
+https://mcp.rodneymandap.com/api/ynab-mcp
+```
+
+## Client Authentication
+
+After a user finishes OAuth, the callback page returns a token beginning with `ynab_`. MCP clients must send:
+
+```text
+Authorization: Bearer <ynab_connection_token>
+```
+
+The YNAB access and refresh tokens stay server-side in the token store and are never sent to the MCP client.
+
+Owner-only fallback is still available for your own use. If `YNAB_ACCESS_TOKEN` and `MCP_API_KEY` are configured, you can send:
+
+```text
+Authorization: Bearer <MCP_API_KEY>
+```
+
+## Local Test
+
+Create `.env.local` with:
+
+```env
+YNAB_CLIENT_ID=your_client_id
+YNAB_CLIENT_SECRET=your_client_secret
+YNAB_REDIRECT_URI=http://localhost:3000/api/ynab/oauth/callback
+```
+
+Start the app and check:
+
+```text
+http://localhost:3000/api/ynab-mcp
+```
+
+You should see the server health response and the available tool names.

--- a/lib/ynab-oauth.ts
+++ b/lib/ynab-oauth.ts
@@ -1,0 +1,259 @@
+import type { NextApiRequest } from "next";
+import crypto from "crypto";
+import { YnabConfigurationError } from "./ynab";
+
+type YnabOAuthTokenResponse = {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
+  scope?: string;
+};
+
+type OAuthStateRecord = {
+  codeVerifier: string;
+  redirectUri: string;
+  createdAt: number;
+};
+
+type YnabConnectionRecord = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  scope?: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+const YNAB_AUTHORIZE_URL = "https://app.ynab.com/oauth/authorize";
+const YNAB_TOKEN_URL = "https://app.ynab.com/oauth/token";
+const STATE_TTL_SECONDS = 10 * 60;
+const CONNECTION_TTL_SECONDS = 90 * 24 * 60 * 60;
+const REFRESH_GRACE_MS = 60 * 1000;
+
+const memoryStore = new Map<string, unknown>();
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new YnabConfigurationError(`${name} is required for YNAB OAuth.`);
+  }
+
+  return value;
+}
+
+function base64Url(input: Buffer): string {
+  return input
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function randomToken(bytes = 32): string {
+  return base64Url(crypto.randomBytes(bytes));
+}
+
+function sha256Base64Url(value: string): string {
+  return base64Url(crypto.createHash("sha256").update(value).digest());
+}
+
+function getOrigin(req: NextApiRequest): string {
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  const proto = typeof forwardedProto === "string" ? forwardedProto : "https";
+  const host = req.headers.host;
+
+  if (!host) {
+    throw new YnabConfigurationError("Unable to determine OAuth redirect host.");
+  }
+
+  return `${proto}://${host}`;
+}
+
+export function getYnabRedirectUri(req: NextApiRequest): string {
+  return process.env.YNAB_REDIRECT_URI || `${getOrigin(req)}/api/ynab/oauth/callback`;
+}
+
+async function redisCommand<T>(command: Array<string | number>): Promise<T | null> {
+  const redisUrl = process.env.UPSTASH_REDIS_REST_URL?.replace(/\/$/, "");
+  const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!redisUrl && !redisToken) {
+    return null;
+  }
+
+  if (!redisUrl || !redisToken) {
+    throw new YnabConfigurationError("Upstash Redis is partially configured.");
+  }
+
+  const endpoint = `${redisUrl}/${command
+    .map((part) => encodeURIComponent(String(part)))
+    .join("/")}`;
+  const response = await fetch(endpoint, {
+    headers: {
+      Authorization: `Bearer ${redisToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Token store returned ${response.status}`);
+  }
+
+  const payload = (await response.json()) as { result?: T; error?: string };
+
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+
+  return payload.result ?? null;
+}
+
+async function storeJson(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+  const stored = await redisCommand<"OK">(["SET", key, JSON.stringify(value), "EX", ttlSeconds]);
+
+  if (!stored) {
+    memoryStore.set(key, value);
+  }
+}
+
+async function readJson<T>(key: string): Promise<T | null> {
+  const stored = await redisCommand<string>(["GET", key]);
+
+  if (stored) {
+    return JSON.parse(stored) as T;
+  }
+
+  return (memoryStore.get(key) as T | undefined) || null;
+}
+
+async function deleteJson(key: string): Promise<void> {
+  await redisCommand<number>(["DEL", key]);
+  memoryStore.delete(key);
+}
+
+function mapTokenResponse(token: YnabOAuthTokenResponse, existingCreatedAt?: number): YnabConnectionRecord {
+  const now = Date.now();
+
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    expiresAt: now + token.expires_in * 1000,
+    scope: token.scope,
+    createdAt: existingCreatedAt || now,
+    updatedAt: now,
+  };
+}
+
+async function requestYnabToken(body: Record<string, string>): Promise<YnabOAuthTokenResponse> {
+  const response = await fetch(YNAB_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: new URLSearchParams(body).toString(),
+  });
+  const payload = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const detail =
+      typeof payload?.error_description === "string"
+        ? payload.error_description
+        : "YNAB OAuth token request failed.";
+    throw new Error(detail);
+  }
+
+  return payload as YnabOAuthTokenResponse;
+}
+
+export async function createYnabAuthorizationUrl(req: NextApiRequest): Promise<string> {
+  const clientId = requireEnv("YNAB_CLIENT_ID");
+  const redirectUri = getYnabRedirectUri(req);
+  const state = randomToken();
+  const codeVerifier = randomToken(48);
+  const codeChallenge = sha256Base64Url(codeVerifier);
+
+  await storeJson(
+    `ynab:oauth:state:${state}`,
+    {
+      codeVerifier,
+      redirectUri,
+      createdAt: Date.now(),
+    } satisfies OAuthStateRecord,
+    STATE_TTL_SECONDS
+  );
+
+  const url = new URL(YNAB_AUTHORIZE_URL);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", "read-only");
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+
+  return url.toString();
+}
+
+export async function completeYnabOAuth(code: string, state: string): Promise<string> {
+  const clientId = requireEnv("YNAB_CLIENT_ID");
+  const clientSecret = requireEnv("YNAB_CLIENT_SECRET");
+  const stateKey = `ynab:oauth:state:${state}`;
+  const stateRecord = await readJson<OAuthStateRecord>(stateKey);
+
+  if (!stateRecord) {
+    throw new Error("OAuth state is invalid or expired. Please start the YNAB connection again.");
+  }
+
+  await deleteJson(stateKey);
+
+  const token = await requestYnabToken({
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uri: stateRecord.redirectUri,
+    grant_type: "authorization_code",
+    code,
+    code_verifier: stateRecord.codeVerifier,
+  });
+  const sessionId = `ynab_${randomToken(32)}`;
+
+  await storeJson(
+    `ynab:connection:${sessionId}`,
+    mapTokenResponse(token),
+    CONNECTION_TTL_SECONDS
+  );
+
+  return sessionId;
+}
+
+export async function getYnabAccessTokenForSession(sessionId: string): Promise<string> {
+  const clientId = requireEnv("YNAB_CLIENT_ID");
+  const clientSecret = requireEnv("YNAB_CLIENT_SECRET");
+  const key = `ynab:connection:${sessionId}`;
+  const connection = await readJson<YnabConnectionRecord>(key);
+
+  if (!connection) {
+    throw new YnabConfigurationError("YNAB OAuth session is invalid or expired.");
+  }
+
+  if (connection.expiresAt > Date.now() + REFRESH_GRACE_MS) {
+    return connection.accessToken;
+  }
+
+  const refreshed = await requestYnabToken({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: connection.refreshToken,
+  });
+  const nextConnection = mapTokenResponse(refreshed, connection.createdAt);
+
+  await storeJson(key, nextConnection, CONNECTION_TTL_SECONDS);
+
+  return nextConnection.accessToken;
+}
+
+export function __resetYnabOAuthMemoryStore() {
+  memoryStore.clear();
+}

--- a/lib/ynab.ts
+++ b/lib/ynab.ts
@@ -1,0 +1,94 @@
+export type YnabClientOptions = {
+  accessToken?: string;
+  apiBase?: string;
+};
+
+export type YnabQuery = Record<string, string | number | boolean | undefined>;
+
+const DEFAULT_YNAB_API_BASE = "https://api.ynab.com/v1";
+
+export class YnabConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "YnabConfigurationError";
+  }
+}
+
+export class YnabApiError extends Error {
+  status: number;
+  details: unknown;
+
+  constructor(status: number, message: string, details: unknown) {
+    super(message);
+    this.name = "YnabApiError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+function getAccessToken(explicitToken?: string): string {
+  const token = explicitToken || process.env.YNAB_ACCESS_TOKEN;
+
+  if (!token) {
+    throw new YnabConfigurationError(
+      "No YNAB access token is available. Connect a YNAB account with OAuth or configure YNAB_ACCESS_TOKEN for owner-only use."
+    );
+  }
+
+  return token;
+}
+
+function buildUrl(apiBase: string, path: string, query?: YnabQuery): string {
+  const url = new URL(`${apiBase.replace(/\/$/, "")}${path}`);
+
+  if (query) {
+    Object.entries(query).forEach(([key, value]) => {
+      if (value !== undefined && value !== "") {
+        url.searchParams.set(key, String(value));
+      }
+    });
+  }
+
+  return url.toString();
+}
+
+export async function ynabGet<T>(
+  path: string,
+  query?: YnabQuery,
+  options: YnabClientOptions = {}
+): Promise<T> {
+  const token = getAccessToken(options.accessToken);
+  const apiBase = options.apiBase || process.env.YNAB_API_BASE || DEFAULT_YNAB_API_BASE;
+  const response = await fetch(buildUrl(apiBase, path, query), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+
+  const payload = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const message =
+      typeof payload?.error?.detail === "string"
+        ? payload.error.detail
+        : `YNAB API request failed with status ${response.status}`;
+    throw new YnabApiError(response.status, message, payload);
+  }
+
+  return payload as T;
+}
+
+export function clampLimit(value: unknown, defaultLimit = 25, maxLimit = 100): number {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultLimit;
+  }
+
+  return Math.min(Math.floor(parsed), maxLimit);
+}
+
+export function currentMonth(): string {
+  return new Date().toISOString().slice(0, 7) + "-01";
+}

--- a/pages/api/ynab-mcp.ts
+++ b/pages/api/ynab-mcp.ts
@@ -1,0 +1,413 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getYnabAccessTokenForSession } from "../../lib/ynab-oauth";
+import { clampLimit, currentMonth, ynabGet } from "../../lib/ynab";
+
+type JsonRpcRequest = {
+  jsonrpc?: "2.0";
+  id?: string | number | null;
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+};
+
+type McpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+const SERVER_INFO = {
+  name: "rodney-ynab-mcp",
+  version: "0.1.0",
+};
+
+const DEFAULT_PLAN_ID = "last-used";
+
+const tools: McpTool[] = [
+  {
+    name: "ynab_list_plans",
+    description: "List available YNAB plans for the configured account.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "ynab_list_accounts",
+    description: "List accounts in a YNAB plan, optionally including closed accounts.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan_id: {
+          type: "string",
+          description: "YNAB plan id. Defaults to last-used.",
+        },
+        include_closed: {
+          type: "boolean",
+          description: "Include closed accounts in the response.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "ynab_list_categories",
+    description: "List category groups and categories for a YNAB plan.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan_id: {
+          type: "string",
+          description: "YNAB plan id. Defaults to last-used.",
+        },
+        include_hidden: {
+          type: "boolean",
+          description: "Include hidden category groups and categories.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "ynab_get_month",
+    description: "Get the month summary for a YNAB plan.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan_id: {
+          type: "string",
+          description: "YNAB plan id. Defaults to last-used.",
+        },
+        month: {
+          type: "string",
+          description: "Month in YYYY-MM-01 format. Defaults to the current month.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "ynab_list_transactions",
+    description:
+      "List YNAB transactions, with optional filters for account, category, payee, month, date range, and status.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan_id: {
+          type: "string",
+          description: "YNAB plan id. Defaults to last-used.",
+        },
+        account_id: { type: "string" },
+        category_id: { type: "string" },
+        payee_id: { type: "string" },
+        month: {
+          type: "string",
+          description: "Month in YYYY-MM-01 format.",
+        },
+        since_date: {
+          type: "string",
+          description: "Only transactions on or after this date, formatted YYYY-MM-DD.",
+        },
+        until_date: {
+          type: "string",
+          description: "Only transactions on or before this date, formatted YYYY-MM-DD.",
+        },
+        type: {
+          type: "string",
+          enum: ["uncategorized", "unapproved"],
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of transactions to return. Defaults to 25, max 100.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "ynab_get_plan_overview",
+    description: "Get a compact overview of accounts, category groups, and the selected month.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan_id: {
+          type: "string",
+          description: "YNAB plan id. Defaults to last-used.",
+        },
+        month: {
+          type: "string",
+          description: "Month in YYYY-MM-01 format. Defaults to the current month.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+];
+
+function getBearerToken(req: NextApiRequest): string | null {
+  const authorization = req.headers.authorization;
+
+  if (authorization?.startsWith("Bearer ")) {
+    return authorization.slice("Bearer ".length);
+  }
+
+  const apiKey = req.headers["x-api-key"];
+  return typeof apiKey === "string" ? apiKey : null;
+}
+
+function jsonRpcResult(id: JsonRpcRequest["id"], result: unknown) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    result,
+  };
+}
+
+function jsonRpcError(id: JsonRpcRequest["id"], code: number, message: string, data?: unknown) {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: {
+      code,
+      message,
+      ...(data ? { data } : {}),
+    },
+  };
+}
+
+function toolText(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+function planId(args: Record<string, unknown>): string {
+  return typeof args.plan_id === "string" && args.plan_id ? args.plan_id : DEFAULT_PLAN_ID;
+}
+
+async function resolveYnabAccessToken(req: NextApiRequest): Promise<string | undefined> {
+  const bearerToken = getBearerToken(req);
+
+  if (bearerToken && bearerToken === process.env.MCP_API_KEY) {
+    return process.env.YNAB_ACCESS_TOKEN;
+  }
+
+  if (bearerToken?.startsWith("ynab_")) {
+    return getYnabAccessTokenForSession(bearerToken);
+  }
+
+  if (!process.env.MCP_API_KEY) {
+    return process.env.YNAB_ACCESS_TOKEN;
+  }
+
+  return undefined;
+}
+
+async function callTool(name: string, args: Record<string, unknown>, accessToken?: string) {
+  switch (name) {
+    case "ynab_list_plans":
+      return toolText(await ynabGet("/plans", undefined, { accessToken }));
+
+    case "ynab_list_accounts": {
+      const response = await ynabGet<{ data: { accounts: Array<{ closed?: boolean }> } }>(
+        `/plans/${encodeURIComponent(planId(args))}/accounts`,
+        undefined,
+        { accessToken }
+      );
+      const includeClosed = args.include_closed === true;
+      return toolText({
+        ...response,
+        data: {
+          ...response.data,
+          accounts: includeClosed
+            ? response.data.accounts
+            : response.data.accounts.filter((account) => !account.closed),
+        },
+      });
+    }
+
+    case "ynab_list_categories": {
+      const response = await ynabGet<{
+        data: {
+          category_groups: Array<{
+            hidden?: boolean;
+            deleted?: boolean;
+            categories?: Array<{ hidden?: boolean; deleted?: boolean }>;
+          }>;
+        };
+      }>(`/plans/${encodeURIComponent(planId(args))}/categories`, undefined, { accessToken });
+      const includeHidden = args.include_hidden === true;
+      return toolText({
+        ...response,
+        data: {
+          ...response.data,
+          category_groups: includeHidden
+            ? response.data.category_groups
+            : response.data.category_groups
+                .filter((group) => !group.hidden && !group.deleted)
+                .map((group) => ({
+                  ...group,
+                  categories: group.categories?.filter(
+                    (category) => !category.hidden && !category.deleted
+                  ),
+                })),
+        },
+      });
+    }
+
+    case "ynab_get_month": {
+      const month = typeof args.month === "string" && args.month ? args.month : currentMonth();
+      return toolText(
+        await ynabGet(
+          `/plans/${encodeURIComponent(planId(args))}/months/${encodeURIComponent(month)}`,
+          undefined,
+          { accessToken }
+        )
+      );
+    }
+
+    case "ynab_list_transactions": {
+      const selectedPlanId = encodeURIComponent(planId(args));
+      const query = {
+        since_date: typeof args.since_date === "string" ? args.since_date : undefined,
+        until_date: typeof args.until_date === "string" ? args.until_date : undefined,
+        type: typeof args.type === "string" ? args.type : undefined,
+      };
+      const limit = clampLimit(args.limit);
+      let path = `/plans/${selectedPlanId}/transactions`;
+
+      if (typeof args.account_id === "string" && args.account_id) {
+        path = `/plans/${selectedPlanId}/accounts/${encodeURIComponent(args.account_id)}/transactions`;
+      } else if (typeof args.category_id === "string" && args.category_id) {
+        path = `/plans/${selectedPlanId}/categories/${encodeURIComponent(args.category_id)}/transactions`;
+      } else if (typeof args.payee_id === "string" && args.payee_id) {
+        path = `/plans/${selectedPlanId}/payees/${encodeURIComponent(args.payee_id)}/transactions`;
+      } else if (typeof args.month === "string" && args.month) {
+        path = `/plans/${selectedPlanId}/months/${encodeURIComponent(args.month)}/transactions`;
+      }
+
+      const response = await ynabGet<{ data: { transactions: unknown[] } }>(path, query, {
+        accessToken,
+      });
+
+      return toolText({
+        ...response,
+        data: {
+          ...response.data,
+          transactions: response.data.transactions.slice(0, limit),
+          limit,
+          returned: Math.min(response.data.transactions.length, limit),
+          total_available: response.data.transactions.length,
+        },
+      });
+    }
+
+    case "ynab_get_plan_overview": {
+      const selectedPlanId = encodeURIComponent(planId(args));
+      const month = typeof args.month === "string" && args.month ? args.month : currentMonth();
+      const [accounts, categories, monthSummary] = await Promise.all([
+        ynabGet(`/plans/${selectedPlanId}/accounts`, undefined, { accessToken }),
+        ynabGet(`/plans/${selectedPlanId}/categories`, undefined, { accessToken }),
+        ynabGet(`/plans/${selectedPlanId}/months/${encodeURIComponent(month)}`, undefined, {
+          accessToken,
+        }),
+      ]);
+
+      return toolText({
+        plan_id: planId(args),
+        selected_month: month,
+        accounts,
+        categories,
+        month_summary: monthSummary,
+      });
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+async function handleMcpRequest(request: JsonRpcRequest, req: NextApiRequest) {
+  const id = request.id ?? null;
+
+  if (request.method === "initialize") {
+    return jsonRpcResult(id, {
+      protocolVersion: "2025-06-18",
+      capabilities: {
+        tools: {},
+      },
+      serverInfo: SERVER_INFO,
+    });
+  }
+
+  if (request.method === "tools/list") {
+    return jsonRpcResult(id, { tools });
+  }
+
+  if (request.method === "tools/call") {
+    const name = request.params?.name;
+
+    if (!name) {
+      return jsonRpcError(id, -32602, "Missing tool name");
+    }
+
+    const args = request.params?.arguments || {};
+    const accessToken = await resolveYnabAccessToken(req);
+    const result = await callTool(name, args, accessToken);
+    return jsonRpcResult(id, result);
+  }
+
+  if (request.method?.startsWith("notifications/")) {
+    return null;
+  }
+
+  return jsonRpcError(id, -32601, `Method not found: ${request.method || "unknown"}`);
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "GET") {
+    return res.status(200).json({
+      ok: true,
+      server: SERVER_INFO,
+      endpoint: "/api/ynab-mcp",
+      connect: "/api/ynab/oauth/connect",
+      auth: "Use the OAuth connection token as Authorization: Bearer <token>.",
+      tools: tools.map((tool) => tool.name),
+    });
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "GET, POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const request = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+
+    if (Array.isArray(request)) {
+      const responses = await Promise.all(request.map((item) => handleMcpRequest(item, req)));
+      return res.status(200).json(responses.filter(Boolean));
+    }
+
+    const response = await handleMcpRequest(request, req);
+
+    if (!response) {
+      return res.status(204).end();
+    }
+
+    return res.status(200).json(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected server error";
+    const status = error instanceof SyntaxError ? 400 : 200;
+    return res.status(status).json(jsonRpcError(null, -32603, message));
+  }
+}

--- a/pages/api/ynab/oauth/callback.ts
+++ b/pages/api/ynab/oauth/callback.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { completeYnabOAuth } from "../../../../lib/ynab-oauth";
+
+function html(body: string) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>YNAB Connected</title>
+  <style>
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; max-width: 720px; margin: 48px auto; padding: 0 24px; color: #111827; }
+    code { display: block; overflow-wrap: anywhere; padding: 16px; background: #f3f4f6; border: 1px solid #e5e7eb; border-radius: 8px; }
+  </style>
+</head>
+<body>${body}</body>
+</html>`;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const code = typeof req.query.code === "string" ? req.query.code : "";
+  const state = typeof req.query.state === "string" ? req.query.state : "";
+
+  if (!code || !state) {
+    return res.status(400).send(html("<h1>Connection failed</h1><p>Missing OAuth code or state.</p>"));
+  }
+
+  try {
+    const sessionId = await completeYnabOAuth(code, state);
+    return res.status(200).send(
+      html(`<h1>YNAB connected</h1>
+<p>Use this token as the bearer token for the MCP server:</p>
+<code>${sessionId}</code>
+<p>The YNAB access and refresh tokens are stored server-side. You can close this tab.</p>`)
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to finish YNAB OAuth.";
+    return res.status(500).send(html(`<h1>Connection failed</h1><p>${message}</p>`));
+  }
+}

--- a/pages/api/ynab/oauth/callback.ts
+++ b/pages/api/ynab/oauth/callback.ts
@@ -1,6 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { completeYnabOAuth } from "../../../../lib/ynab-oauth";
 
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function html(body: string) {
   return `<!doctype html>
 <html lang="en">
@@ -35,11 +44,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(200).send(
       html(`<h1>YNAB connected</h1>
 <p>Use this token as the bearer token for the MCP server:</p>
-<code>${sessionId}</code>
+<code>${escapeHtml(sessionId)}</code>
 <p>The YNAB access and refresh tokens are stored server-side. You can close this tab.</p>`)
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unable to finish YNAB OAuth.";
-    return res.status(500).send(html(`<h1>Connection failed</h1><p>${message}</p>`));
+    return res.status(500).send(html(`<h1>Connection failed</h1><p>${escapeHtml(message)}</p>`));
   }
 }

--- a/pages/api/ynab/oauth/connect.ts
+++ b/pages/api/ynab/oauth/connect.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createYnabAuthorizationUrl } from "../../../../lib/ynab-oauth";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const authorizationUrl = await createYnabAuthorizationUrl(req);
+    return res.redirect(302, authorizationUrl);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to start YNAB OAuth.";
+    return res.status(500).json({ error: message });
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,19 @@
     "pages/api/contact.ts": {
       "maxDuration": 10,
       "memory": 1024
+    },
+    "pages/api/ynab-mcp.ts": {
+      "maxDuration": 10,
+      "memory": 1024
+    },
+    "pages/api/ynab/oauth/connect.ts": {
+      "maxDuration": 10,
+      "memory": 1024
+    },
+    "pages/api/ynab/oauth/callback.ts": {
+      "maxDuration": 10,
+      "memory": 1024
     }
   },
-"regions": ["hkg1"]
+  "regions": ["hkg1"]
 }


### PR DESCRIPTION
## Summary

Adds a read-only YNAB MCP server that can be deployed from the existing Next.js/Vercel portfolio project and connected to ChatGPT through an MCP client.

## What Changed

- Added /api/ynab-mcp for MCP initialize, tool discovery, and read-only YNAB tool calls.
- Added YNAB OAuth connect and callback endpoints under /api/ynab/oauth/*.
- Added server-side OAuth token handling with refresh support and Upstash Redis persistence for production.
- Kept an owner-only fallback path using YNAB_ACCESS_TOKEN and MCP_API_KEY.
- Added provisioning documentation for YNAB OAuth app setup, Vercel environment variables, Redis token storage, and MCP client authentication.
- Added tests covering MCP protocol handling, YNAB API calls, OAuth redirects, callback exchange, token use, and error cases.

## Impact

This moves the server from a single-owner personal access token model to a multi-user OAuth model, so users can authorize their own YNAB accounts without sharing credentials or personal access tokens.

## Validation

- npm run build
- npm run test:ci

94 tests passing.