### PR TITLE
Return OAuth challenges for unauthenticated MCP tool calls

### DIFF
--- a/__tests__/ynab-mcp.test.ts
+++ b/__tests__/ynab-mcp.test.ts
@@ -101,24 +101,38 @@ describe("/api/ynab-mcp", () => {
     );
   });
 
-  it("requires a valid owner token for tool calls when MCP_API_KEY is configured", async () => {
+  it("returns an OAuth challenge for unauthenticated tool calls when MCP_API_KEY is configured", async () => {
     process.env.MCP_API_KEY = "secret";
     delete process.env.YNAB_ACCESS_TOKEN;
-    const req = createMockRequest("POST", {
-      jsonrpc: "2.0",
-      id: 1,
-      method: "tools/call",
-      params: {
-        name: "ynab_list_plans",
-        arguments: {},
+    const req = createMockRequest(
+      "POST",
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "ynab_list_plans",
+          arguments: {},
+        },
       },
-    });
+      { host: "mcp.example.com", "x-forwarded-proto": "https" }
+    );
     const res = createMockResponse();
 
     await handler(req, res);
 
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json.mock.calls[0][0].error.message).toContain("No YNAB access token");
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "WWW-Authenticate",
+      expect.stringContaining(
+        'authorization_uri="https://mcp.example.com/api/ynab/oauth/connect"'
+      )
+    );
+    expect(res.json).toHaveBeenCalledWith({
+      error: "authorization_required",
+      error_description: "Connect a YNAB account with OAuth to use this MCP tool.",
+      connect: "https://mcp.example.com/api/ynab/oauth/connect",
+    });
   });
 
   it("calls YNAB when a tool is invoked", async () => {
@@ -361,7 +375,7 @@ describe("/api/ynab-mcp", () => {
     expect(unknownToolRes.json.mock.calls[0][0].error.code).toBe(-32603);
   });
 
-  it("handles YNAB configuration and API errors as tool errors", async () => {
+  it("returns an OAuth challenge when no YNAB token is available", async () => {
     delete process.env.YNAB_ACCESS_TOKEN;
     const missingTokenReq = createMockRequest("POST", {
       jsonrpc: "2.0",
@@ -372,10 +386,20 @@ describe("/api/ynab-mcp", () => {
     const missingTokenRes = createMockResponse();
     await handler(missingTokenReq, missingTokenRes);
 
-    expect(missingTokenRes.json.mock.calls[0][0].error.message).toContain(
-      "No YNAB access token"
+    expect(missingTokenRes.status).toHaveBeenCalledWith(401);
+    expect(missingTokenRes.setHeader).toHaveBeenCalledWith(
+      "WWW-Authenticate",
+      expect.stringContaining('authorization_uri="/api/ynab/oauth/connect"')
     );
+    expect(missingTokenRes.json.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        error: "authorization_required",
+        connect: "/api/ynab/oauth/connect",
+      })
+    );
+  });
 
+  it("handles YNAB API errors as tool errors", async () => {
     process.env.YNAB_ACCESS_TOKEN = "ynab-test-token";
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: false,
@@ -392,6 +416,44 @@ describe("/api/ynab-mcp", () => {
     await handler(apiErrorReq, apiErrorRes);
 
     expect(apiErrorRes.json.mock.calls[0][0].error.message).toBe("Rate limited");
+  });
+
+  it("returns an OAuth challenge for expired OAuth session bearer tokens", async () => {
+    delete process.env.YNAB_ACCESS_TOKEN;
+    process.env.YNAB_CLIENT_ID = "client-id";
+    process.env.YNAB_CLIENT_SECRET = "client-secret";
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example.com";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "redis-token";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: null }),
+    });
+    const req = createMockRequest(
+      "POST",
+      {
+        jsonrpc: "2.0",
+        id: 13,
+        method: "tools/call",
+        params: { name: "ynab_list_plans", arguments: {} },
+      },
+      { authorization: "Bearer ynab_expired", host: "mcp.example.com" }
+    );
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "WWW-Authenticate",
+      expect.stringContaining(
+        'authorization_uri="https://mcp.example.com/api/ynab/oauth/connect"'
+      )
+    );
+    expect(res.json.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        error: "authorization_required",
+      })
+    );
   });
 
   it("handles batches, invalid JSON, and unsupported methods", async () => {

--- a/pages/api/ynab-mcp.ts
+++ b/pages/api/ynab-mcp.ts
@@ -25,6 +25,14 @@ const SERVER_INFO = {
 };
 
 const DEFAULT_PLAN_ID = "last-used";
+const OAUTH_CONNECT_PATH = "/api/ynab/oauth/connect";
+
+class McpAuthRequiredError extends Error {
+  constructor() {
+    super("Connect a YNAB account with OAuth to use this MCP tool.");
+    this.name = "McpAuthRequiredError";
+  }
+}
 
 const tools: McpTool[] = [
   {
@@ -159,6 +167,35 @@ function getBearerToken(req: NextApiRequest): string | null {
   return typeof apiKey === "string" ? apiKey : null;
 }
 
+function getRequestOrigin(req: NextApiRequest): string {
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  const proto = typeof forwardedProto === "string" ? forwardedProto : "https";
+  const host = req.headers.host;
+
+  return host ? `${proto}://${host}` : "";
+}
+
+function getConnectUrl(req: NextApiRequest): string {
+  const origin = getRequestOrigin(req);
+
+  return origin ? `${origin}${OAUTH_CONNECT_PATH}` : OAUTH_CONNECT_PATH;
+}
+
+function quoteHeaderValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function oauthChallengeHeader(req: NextApiRequest): string {
+  const connectUrl = getConnectUrl(req);
+
+  return [
+    'Bearer realm="rodney-ynab-mcp"',
+    'error="invalid_token"',
+    'error_description="Connect a YNAB account with OAuth."',
+    `authorization_uri="${quoteHeaderValue(connectUrl)}"`,
+  ].join(", ");
+}
+
 function jsonRpcResult(id: JsonRpcRequest["id"], result: unknown) {
   return {
     jsonrpc: "2.0",
@@ -202,14 +239,18 @@ async function resolveYnabAccessToken(req: NextApiRequest): Promise<string | und
   }
 
   if (bearerToken?.startsWith("ynab_")) {
-    return getYnabAccessTokenForSession(bearerToken);
+    try {
+      return await getYnabAccessTokenForSession(bearerToken);
+    } catch {
+      throw new McpAuthRequiredError();
+    }
   }
 
   if (!process.env.MCP_API_KEY) {
     return process.env.YNAB_ACCESS_TOKEN;
   }
 
-  return undefined;
+  throw new McpAuthRequiredError();
 }
 
 async function callTool(name: string, args: Record<string, unknown>, accessToken?: string) {
@@ -362,6 +403,11 @@ async function handleMcpRequest(request: JsonRpcRequest, req: NextApiRequest) {
 
     const args = request.params?.arguments || {};
     const accessToken = await resolveYnabAccessToken(req);
+
+    if (!accessToken && !process.env.YNAB_ACCESS_TOKEN) {
+      throw new McpAuthRequiredError();
+    }
+
     const result = await callTool(name, args, accessToken);
     return jsonRpcResult(id, result);
   }
@@ -379,7 +425,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ok: true,
       server: SERVER_INFO,
       endpoint: "/api/ynab-mcp",
-      connect: "/api/ynab/oauth/connect",
+      connect: OAUTH_CONNECT_PATH,
       auth: "Use the OAuth connection token as Authorization: Bearer <token>.",
       tools: tools.map((tool) => tool.name),
     });
@@ -406,6 +452,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     return res.status(200).json(response);
   } catch (error) {
+    if (error instanceof McpAuthRequiredError) {
+      const connect = getConnectUrl(req);
+
+      res.setHeader("WWW-Authenticate", oauthChallengeHeader(req));
+      return res.status(401).json({
+        error: "authorization_required",
+        error_description: error.message,
+        connect,
+      });
+    }
+
     const message = error instanceof Error ? error.message : "Unexpected server error";
     const status = error instanceof SyntaxError ? 400 : 200;
     return res.status(status).json(jsonRpcError(null, -32603, message));


### PR DESCRIPTION
## Summary
- Return HTTP 401 OAuth challenges when MCP tool calls lack valid YNAB authentication.
- Build absolute authorization URLs from forwarded request origin details.
- Cover missing API keys, missing tokens, and expired OAuth sessions with tests.

## Testing
- Added and updated Jest coverage for OAuth challenge responses and YNAB API errors.